### PR TITLE
Reduced Animation timeout & position set into relative parent

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -12,8 +12,8 @@ import JobseekerProfile from './pages/JobseekerProfile'
 const Routes = () => (
   <Route
     render={({ location }) => (
-      <TransitionGroup>
-        <CSSTransition key={location.key} timeout={600} classNames="fade">
+      <TransitionGroup className="app">
+        <CSSTransition key={location.key} timeout={300} classNames="fade">
           <Switch location={location}>
             <Route exact path="/" component={Landing} />
             <Route exact path="/login" component={Login} />

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -187,10 +187,14 @@ Button.register-button {
 }
 
 // Route Navigation Animation
+.app {
+  position: relative;
+}
+
 .page {
   position: absolute;
-  left: 0;
   right: 0;
+  left: 0;
 }
 
 .fade-appear,
@@ -202,7 +206,7 @@ Button.register-button {
 .fade-appear-active,
 .fade-enter.fade-enter-active {
   opacity: 1;
-  transition: opacity 400ms linear 200ms;
+  transition: opacity 300ms linear 150ms;
 }
 
 .fade-exit {
@@ -211,5 +215,5 @@ Button.register-button {
 
 .fade-exit.fade-exit-active {
   opacity: 0;
-  transition: opacity 200ms linear;
+  transition: opacity 150ms linear;
 }


### PR DESCRIPTION
I don't have the page moving after rendering. However, the timeout is reduced for faster effect and the animation functionality is placed into a relative parent. Kindly check and revert.