### PR TITLE
Landing page text style

### DIFF
--- a/src/components/LandingTop/index.tsx
+++ b/src/components/LandingTop/index.tsx
@@ -26,21 +26,19 @@ const LandingTop = () => {
         <div className="row m-auto">
           <div className="col-md-8 align-items-center d-flex justify-content-center">
             <div className="card-body">
-              <h1 className="heading">TINDEV</h1>
+              <h1 className="heading">Tindev</h1>
               <animated.h2 style={scrollIn} className="card-title">
-                Connection between employees and employers
+                Connection between companies and applicants
               </animated.h2>
 
               <animated.p style={showIn} className="card-text">
-                Cras sit amet nibh libero, in gravida nulla. Nulla vel metus
-                scelerisque ante sollicitudin commodo. Cras purus odio,
-                vestibulum.
+                Get your real match without hatch.
               </animated.p>
-              <p className="card-text">
+              {/* <p className="card-text">
                 <small className="font-weight-light">
                   Application for both developers and employers
                 </small>
-              </p>
+              </p> */}
               <animated.div style={showIn} className="pt-1">
                 <Link
                   to="/register"

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -8,15 +8,28 @@
   color: $white;
 }
 
+q {
+  color: #ce1370;
+}
+
 .heading {
-  font-family: 'Merriweather Sans', sans-serif;
-  letter-spacing: 1rem;
+  // font-family: 'Merriweather Sans', sans-serif;
+  letter-spacing: 0.01rem;
+  padding-bottom: 1rem;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 2.77rem;
+  font-weight: bold;
+}
+
+.card-title {
+  font-size: 1.8rem;
 }
 
 .profile-page {
   margin: auto;
   width: 60%;
 }
+
 .container {
   height: 95vh;
 }


### PR DESCRIPTION
I suggest we change the style on the landing page a bit. Instead of all upper-case letters in the app name, I would use either all lower-case or first letter capitalized. That's more easy-going looking text as it refers to tinder. 
Less text prevents this from happening: 
![landingPageMobile](https://user-images.githubusercontent.com/45182330/104321059-67c1de00-54e3-11eb-9d66-08c63f4807eb.png)
My suggestion:
![landingpage](https://user-images.githubusercontent.com/45182330/104321153-87f19d00-54e3-11eb-9423-b110bf750a60.png)
![landingpageMobile](https://user-images.githubusercontent.com/45182330/104321166-8e801480-54e3-11eb-99fb-db59623939ef.png)
The text under the header is just for a reference.. :))